### PR TITLE
Add require.js paths option to alias paths to external libraries.

### DIFF
--- a/lib/amd-loader.js
+++ b/lib/amd-loader.js
@@ -5,9 +5,9 @@ var Module = require("module");
 var moduleStack = [];
 var defaultCompile = module.constructor.prototype._compile;
 
-module.constructor.prototype._compile = function(content, filename){  
+module.constructor.prototype._compile = function(content, filename){
     moduleStack.push(this);
-    try {        
+    try {
         return defaultCompile.call(this, content, filename);
     }
     finally {
@@ -15,12 +15,14 @@ module.constructor.prototype._compile = function(content, filename){
     }
 };
 
+var paths = exports.paths = {};
+
 global.define = function (id, injects, factory) {
 
     // infere the module
     var currentModule = moduleStack[moduleStack.length-1];
     var module = currentModule || require.main;
-    
+
     // parse arguments
     if (!factory) {
         // two or less arguments
@@ -36,7 +38,7 @@ global.define = function (id, injects, factory) {
             }
             else{
                 // anonymous, deps included
-                injects = id;          
+                injects = id;
             }
         }
         else {
@@ -51,29 +53,38 @@ global.define = function (id, injects, factory) {
             // async require
             return callback.apply(this, relativeId.map(req))
         }
-        
+
         var chunks = relativeId.split("!");
         if (chunks.length >= 2) {
             var prefix = chunks[0];
             relativeId = chunks.slice(1).join("!");
         }
-        
-        var id = Module._resolveFilename(relativeId, module)[0];
-        
+
+        for (var _path in paths) {
+            if (relativeId.slice(0, _path.length) == _path) {
+                var replace = paths[_path];
+                relativeId = replace + relativeId.slice(_path.length);
+                break;
+            }
+        }
+
+        var id = Module._resolveFilename(relativeId, module);
+
         if (prefix && prefix.indexOf("text") !== -1) {
             return fs.readFileSync(id);
-        } else
+        } else {
             return require(id);
+        }
     }.bind(this, module);
 
-    injects.unshift("require", "exports", "module");
-    
+    injects.push("require", "exports", "module");
+
     id = module.id;
     if (typeof factory !== "function") {
         // we can just provide a plain object
         return module.exports = factory;
     }
-    
+
     var returned = factory.apply(module.exports, injects.map(function (injection) {
         switch (injection) {
             // check for CommonJS injection variables
@@ -85,7 +96,7 @@ global.define = function (id, injects, factory) {
                 return req(injection);
         }
     }));
-    
+
     if (returned) {
         // since AMD encapsulates a function/callback, it can allow the factory to return the exports.
         module.exports = returned;


### PR DESCRIPTION
This way you can alias external libraries to a more convenient path, instead of typing the while pathname.

Also changed injects.unshift to injects.push, so the dependencies array of the define call, are the first arguments.
